### PR TITLE
As a User I would like to disable the Convert-Decimals-To-Unrelated-Dates "Feature".

### DIFF
--- a/ansible/config/datapusher.wsgi
+++ b/ansible/config/datapusher.wsgi
@@ -1,0 +1,14 @@
+import os
+import sys
+import hashlib
+
+activate_this = os.path.join('/usr/lib/ckan/datapusher/bin/activate_this.py')
+execfile(activate_this, dict(__file__=activate_this))
+
+import ckanserviceprovider.web as web
+os.environ['JOB_CONFIG'] = '/etc/ckan/datapusher_settings.py'
+web.configure()
+
+import datapusher.jobs as jobs
+
+application = web.app

--- a/ansible/config/datapusher_settings.py
+++ b/ansible/config/datapusher_settings.py
@@ -1,0 +1,31 @@
+import uuid
+import messytables
+
+DEBUG = False
+TESTING = False
+SECRET_KEY = str(uuid.uuid4())
+USERNAME = str(uuid.uuid4())
+PASSWORD = str(uuid.uuid4())
+
+NAME = 'datapusher'
+
+# database
+
+SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/job_store.db'
+
+# webserver host and port
+
+HOST = '0.0.0.0'
+PORT = 8800
+HOST = '127.0.0.1'
+# logging
+
+#FROM_EMAIL = 'server-error@example.com'
+#ADMINS = ['yourname@example.com']  # where to send emails
+
+#LOG_FILE = '/tmp/ckan_service.log'
+STDERR = True
+
+
+TYPES = [messytables.StringType, messytables.DecimalType,
+         messytables.IntegerType]

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -30,6 +30,13 @@
   roles:
     - datastore
 
+- name: install and configure DataPusher
+  sudo: yes
+  user: ubuntu
+  hosts: webservers
+  roles:
+    - datapusher
+
 - name: install and configure FileStore
   sudo: yes
   user: ubuntu

--- a/ansible/deploy_test.yml
+++ b/ansible/deploy_test.yml
@@ -30,6 +30,13 @@
   roles:
     - datastore
 
+- name: install and configure DataPusher
+  sudo: yes
+  user: ubuntu
+  hosts: webservers
+  roles:
+    - datapusher
+
 - name: install and configure FileStore
   sudo: yes
   user: ubuntu

--- a/ansible/roles/datapusher/tasks/main.yml
+++ b/ansible/roles/datapusher/tasks/main.yml
@@ -2,6 +2,10 @@
 #
 # Let's make ourselves a datapusher that isn't embarrassing.
 #
+- name: Kill the OKFN Datapusher
+  file: path=/usr/lib/ckan/datapusher/src/datapusher
+        state=absent
+
 - name: Install backported Datapusher
   git: repo=https://github.com/nhsengland/datapusher
        dest=/usr/lib/ckan/datapusher/src/datapusher

--- a/ansible/roles/datapusher/tasks/main.yml
+++ b/ansible/roles/datapusher/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+#
+# Let's make ourselves a datapusher that isn't embarrassing.
+#
+- name: Install backported Datapusher
+  git: repo=https://github.com/nhsengland/datapusher
+       dest=/usr/lib/ckan/datapusher/src/datapusher
+       version=type_configuration
+
+- name: Update backported Datapusher WSGI file
+  template: src=config/datapusher.wsgi dest=/etc/ckan/datapusher.wsgi
+
+- name: Configure the Datapusher
+  template: src=config/datapusher_settings.py dest=/etc/ckan/datapusher_settings.py


### PR DESCRIPTION
Deploy our backport of Datapusher PR #65.

Configure the datapusher not to try & understand dates.

Because it demonstrably doesn't.