### PR TITLE
S3-Almost-Be-Gone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ansible/hosts
 *~
 *.pyc
 tests/performance_tests/*/results
+*.log

--- a/ansible/scripts/backup.sh
+++ b/ansible/scripts/backup.sh
@@ -24,8 +24,7 @@ mkdir -p "$backup_dir"
 sudo su - postgres -c "pg_dump -Fc datastore_default" > "$backup_dir/datastore_default.dump"
 
 # Copy the filestore directory into the backup directory. This will contain any
-# newly uploaded data-source assets (it's just an extra source of safety in
-# case the S3 push at the end fails).
+# newly uploaded data-source assets.
 sudo cp -r /var/lib/ckan/default "$backup_dir/default"
 
 # Create the tgz
@@ -38,7 +37,3 @@ python upload.py $backup_target
 if [ $? -eq 0 ] then
   rm $backup_target
 fi
-
-
-# Push any new data-source assets to S3
-sudo /usr/lib/ckan/default/bin/paster --plugin=ckanext-s3archive s3archive archive -c /etc/ckan/default/production.ini


### PR DESCRIPTION
Stops uploading of files to S3, plugin remains in order to redirect downloads of existing S3 stored files. NEEDS FIXING AT SOME LATER DATE.