### PR TITLE
Upgrade Ansible & Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ ansible/hosts
 tests/performance_tests/*/results
 *.log
 *.pem
-ansible.cfg
 .vault.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/performance_tests/*/results
 *.log
 *.pem
 ansible.cfg
+.vault.txt

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -37,17 +37,17 @@ Make sure you have the Ansible vault password in the .vault.txt file (available 
 
 Simply run the following command in this directory and "it should just work" (tm) to install a test instance::
 
-    ansible-playbook -i hosts deploy_test.yml --vault-password-file ~/.vault.txt
+    ansible-playbook hosts deploy_test.yml --vault-password-file .vault.txt
 
 This brings up an empty "basic" CKAN instance with NHSEngland branding.
 
 If you want to deploy a "full" production type instance with all the bells and whistles, you need to type::
 
-    ansible-playbook -i hosts deploy_prod.yml --vault-password-file ~/.vault.txt
+    ansible-playbook hosts deploy_prod.yml --vault-password-file .vault.txt
 
 If you just want to deploy publish-o-matic then you need to run::
 
-    ansible-playbook -i hosts deploy_publishomatic.yml --vault-password-file ~/.vault.txt
+    ansible-playbook hosts deploy_publishomatic.yml --vault-password-file .vault.txt
 
 Configuring publishomatic
 -------------------------
@@ -69,7 +69,7 @@ Deploying changes to Ckanext NHSEngland
 
 Simply run the following command in this directory and "it should just work" (tm)::
 
-    ansible-playbook -i hosts update.yml --vault-password-file ~/.vault.txt
+    ansible-playbook hosts update.yml --vault-password-file .vault.txt
 
 
 Rolling back changes to Ckanext NHSEngland
@@ -83,8 +83,8 @@ You can roll back either to tags (by name), or to specific commits (by hash).
 
 Example commandline usage::
 
-     ansible-playbook -i hosts rollback.yml --extra-vars="tag=Alpha" --vault-password-file ~/.vault.txt
-     ansible-playbook -i hosts rollback.yml --extra-vars="commit=ec8f7ae323bdfcc8baa68d669b913e4fd23fb999" --vault-password-file ~/.vault.txt
+     ansible-playbook hosts rollback.yml --extra-vars="tag=Alpha" --vault-password-file .vault.txt
+     ansible-playbook hosts rollback.yml --extra-vars="commit=ec8f7ae323bdfcc8baa68d669b913e4fd23fb999" --vault-password-file .vault.txt
 
 Database backup and restore
 ---------------------------

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -28,7 +28,7 @@ Make sure you create/update the hosts file to something like the following::
 
 (Replace with the appropriate hostname[s] - look in hosts.example for hints)
 
-Please ensure you have the correct keys (pem) for the instances you hope to manage.
+Please ensure you have the correct pem file for the instances you hope to manage.  It should live in `~/.ssh`.  If you want to keep it somewhere else you will need to modify your working copy of `ansible/ansible.cfg`.
 
 Deploying
 ---------

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -7,10 +7,10 @@ various sysop-y type "stuff".
 Setup
 -----
 
-You need to have Ansible installed. Make sure it is a recent (>1.6) version or you will encounter
-errors running the deb module
+You need to have Ansible installed. Make sure it is a recent (>2.4) version or you will encounter
+errors running the deb module.
 
-I simply created a virtualenv and pip installed ansible. Full docs here: http://docs.ansible.com/index.html
+The cleanest way to do this is with `pipsi <https://github.com/mitsuhiko/pipsi>`.  Full ansible docs here: http://docs.ansible.com/index.html
 
 Make sure you create/update the hosts file to something like the following::
 

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
-private_key_file=~/.ssh/nhs-england-data.pem
+inventory = hosts
+private_key_file = ~/.ssh/nhs-england-data.pem
 
 [ssh_connection]
-pipelining=True
+pipelining = True

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+private_key_file=~/.ssh/nhs-england-data.pem
+
+[ssh_connection]
+pipelining=True

--- a/ansible/config/apache.wsgi
+++ b/ansible/config/apache.wsgi
@@ -1,0 +1,9 @@
+import os
+activate_this = os.path.join('/usr/lib/ckan/default/bin/activate_this.py')
+execfile(activate_this, dict(__file__=activate_this))
+
+from paste.deploy import loadapp
+config_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'production.ini')
+from paste.script.util.logging_config import fileConfig
+fileConfig(config_filepath)
+application = loadapp('config:%s' % config_filepath)

--- a/ansible/config/apache2_ckan_default
+++ b/ansible/config/apache2_ckan_default
@@ -22,4 +22,14 @@ WSGISocketPrefix /var/run/wsgi
     ErrorLog /var/log/apache2/ckan_default.error.log
     CustomLog /var/log/apache2/ckan_default.custom.log combined
 
+    <IfModule mod_rpaf.c>
+        RPAFenable On
+        RPAFsethostname On
+        RPAFproxy_ips 127.0.0.1
+    </IfModule>
+
+    <Directory />
+        Require all granted
+    </Directory>
+
 </VirtualHost>

--- a/ansible/config/apache2_ckan_default
+++ b/ansible/config/apache2_ckan_default
@@ -1,5 +1,5 @@
 WSGISocketPrefix /var/run/wsgi
-<VirtualHost 0.0.0.0:8080>
+<VirtualHost 127.0.0.1:8080>
 
     ServerName data.england.nhs.uk
     ServerAlias www.data.england.nhs.uk

--- a/ansible/deploy_directory.yml
+++ b/ansible/deploy_directory.yml
@@ -1,5 +1,0 @@
-- name: Deploy Directory
-  user: ubuntu
-  hosts: webservers
-  roles:
-    - directory

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -18,6 +18,13 @@
   roles:
     - pip
 
+- name: install Apache
+  become: true
+  user: ubuntu
+  hosts: webservers
+  roles:
+    - apache
+
 - name: install CKAN
   become: true
   user: ubuntu

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -18,6 +18,13 @@
   roles:
     - pip
 
+- name: install and configure SOLR
+  become: true
+  user: ubuntu
+  hosts: solr
+  roles:
+    - solr
+
 - name: install Apache
   become: true
   user: ubuntu
@@ -38,13 +45,6 @@
   hosts: webservers
   roles:
     - ckan
-
-- name: install and configure SOLR
-  become: true
-  user: ubuntu
-  hosts: solr
-  roles:
-    - solr
 
 - name: install and configure DataStore
   become: true

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -122,6 +122,12 @@
       - name: restart Nginx
         service: name=nginx state=restarted
 
+- name: deploy data directory
+  user: ubuntu
+  hosts: webservers
+  roles:
+    - directory
+
 - name: configure backup scripts
   become: true
   user: ubuntu

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -3,84 +3,84 @@
 # NHSEngland. Assumes a 64bit Ubuntu LTS as the target OS.
 
 - name: install CKAN
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - ckan
 
 - name: install and configure SOLR
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: solr
   roles:
     - solr
 
 - name: install and configure Postgres
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: dbservers
   roles:
     - db
 
 - name: install and configure DataStore
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: dbservers
   roles:
     - datastore
 
 - name: install and configure DataPusher
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - datapusher
 
 - name: install and configure FileStore
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - filestore
 
 - name: install plugin
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - plugin
 
 - name: install adfs
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - adfs
 
 - name: configure email
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - email
 
 - name: configure S3 filestore
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - s3
 
 - name: configure SSL
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - ssl
 
 - name: configure ckan
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   tasks:
@@ -102,7 +102,7 @@
         service: name=nginx state=restarted
 
 - name: configure backup scripts
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: dbservers
   roles:

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -2,6 +2,22 @@
 # This playbook deploys/installs a complete CKAN isolated instance for
 # NHSEngland. Assumes a 64bit Ubuntu LTS as the target OS.
 
+- name: "Bootstrap Python 2"
+  become: true
+  hosts: all
+  gather_facts: false
+  user: ubuntu
+  tasks:
+    - name: Install Python 2
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+
+- name: Modernise pip
+  become: true
+  user: ubuntu
+  hosts: dbservers
+  roles:
+    - pip
+
 - name: install CKAN
   become: true
   user: ubuntu

--- a/ansible/deploy_prod.yml
+++ b/ansible/deploy_prod.yml
@@ -25,6 +25,13 @@
   roles:
     - apache
 
+- name: install and configure Postgres
+  become: true
+  user: ubuntu
+  hosts: dbservers
+  roles:
+    - db
+
 - name: install CKAN
   become: true
   user: ubuntu
@@ -38,13 +45,6 @@
   hosts: solr
   roles:
     - solr
-
-- name: install and configure Postgres
-  become: true
-  user: ubuntu
-  hosts: dbservers
-  roles:
-    - db
 
 - name: install and configure DataStore
   become: true
@@ -111,12 +111,10 @@
         template: src=config/prod_settings.ini dest=/etc/ckan/default/production.ini
 
       - name: initialise the database
-        command: ckan db init
-
+        command: /usr/lib/ckan/default/bin/paster --plugin=ckan db init -c /etc/ckan/default/production.ini
 
       - name: Set DataStore database permissions
-        command: ckan datastore set-permissions postgres
-
+        command: /usr/lib/ckan/default/bin/paster --plugin=ckan datastore set-permissions -c /etc/ckan/default/production.ini postgres
 
       - name: restart Apache
         service: name=apache2 state=restarted

--- a/ansible/deploy_test.yml
+++ b/ansible/deploy_test.yml
@@ -3,56 +3,56 @@
 # NHSEngland. Assumes a 64bit Ubuntu LTS as the target OS.
 
 - name: install CKAN
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - ckan
 
 - name: install and configure SOLR
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: solr
   roles:
     - solr
 
 - name: install and configure Postgres
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: dbservers
   roles:
     - db
 
 - name: install and configure DataStore
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: dbservers
   roles:
     - datastore
 
 - name: install and configure DataPusher
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - datapusher
 
 - name: install and configure FileStore
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - filestore
 
 - name: install plugin
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   roles:
     - plugin
 
 - name: configure ckan
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: webservers
   tasks:
@@ -74,7 +74,7 @@
         service: name=nginx state=restarted
 
 - name: configure backup scripts
-  sudo: yes
+  become: true
   user: ubuntu
   hosts: dbservers
   tasks:

--- a/ansible/forks.yml
+++ b/ansible/forks.yml
@@ -8,7 +8,7 @@
     # BRANCHES ARE AWESOME.
     branch: datadirectory
   hosts: webservers
-  sudo: yes
+  become: true
   user: ubuntu
   gather_facts: false
   tasks:

--- a/ansible/roles/adfs/tasks/main.yml
+++ b/ansible/roles/adfs/tasks/main.yml
@@ -15,11 +15,16 @@
     - swig
     - python-dev
 
-- name: clone git repository
-  git: repo={{ git_protocol }}{{ git_repos_adfs }}
-       dest=/home/ubuntu/ckanext-adfs
+- name: clone ckanext-adfs git repository
+  become: true
+  become_user: ubuntu
+  git:
+    repo: "{{ git_protocol }}{{ git_repos_adfs }}"
+    dest: /home/ubuntu/ckanext-adfs
 
-- name: run setup.py for the plugin
+- name: run setup.py for adfs plugin
+  become: true
+  become_user: ubuntu
   command: /usr/lib/ckan/default/bin/python setup.py develop chdir=/home/ubuntu/ckanext-adfs
 
 - name: download the FederationMetadata.xml file

--- a/ansible/roles/apache/handlers/main.yml
+++ b/ansible/roles/apache/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+# Handlers for web related services. Such handlers are called by other "plays"
+
+- name: Restart Apache
+  service: name=apache2 state=restarted

--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -4,6 +4,7 @@
   apt: pkg={{ item }} state=installed
   with_items:
     - apache2
+    - libapache2-mod-rpaf
     - libapache2-mod-wsgi
 
 - name: remove default Apache site

--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -15,7 +15,17 @@
 - name: Apache listen on port 8080
   lineinfile: dest=/etc/apache2/ports.conf regexp="^Listen 80" line="Listen 8080" state=present
 
-- name: configure Apache
-  copy: src=config/apache2_ckan_default dest=/etc/apache2/sites-available/ckan_default.conf mode=0644 owner=root
+- name: copy Apache vhost configuration
+  template:
+    src: config/apache2_ckan_default
+    dest: /etc/apache2/sites-available/ckan_default.conf
+    mode: 664
+    owner: root
+
+- name: enable Apache vhost
+  file:
+    src: /etc/apache2/sites-available/ckan_default.conf
+    dest: /etc/apache2/sites-enabled/ckan_default.conf
+    state: link
   notify:
     - Restart Apache

--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# This playbook installs Apache with non-default ports
+- name: install and configure Apache
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - apache2
+    - libapache2-mod-wsgi
+
+- name: remove default Apache site
+  file:
+    path: /etc/apache2/sites-enabled/000-default.conf
+    state: absent
+
+- name: Apache listen on port 8080
+  lineinfile: dest=/etc/apache2/ports.conf regexp="^Listen 80" line="Listen 8080" state=present
+
+- name: configure Apache
+  copy: src=config/apache2_ckan_default dest=/etc/apache2/sites-available/ckan_default.conf mode=0644 owner=root
+  notify:
+    - Restart Apache

--- a/ansible/roles/backup/tasks/main.yml
+++ b/ansible/roles/backup/tasks/main.yml
@@ -3,7 +3,8 @@
 # instance.
 
 - name: install requests
-  sudo: true
+  become: true
+  become_user: ubuntu
   pip: name=requests virtualenv=/usr/lib/ckan/default
 
 - name: install packages for backup

--- a/ansible/roles/ckan/handlers/main.yml
+++ b/ansible/roles/ckan/handlers/main.yml
@@ -4,5 +4,8 @@
 - name: Restart Apache
   service: name=apache2 state=restarted
 
+- name: Restart Jetty
+  service: name=jetty8 state=restarted
+
 - name: Restart Nginx
   service: name=nginx state=restarted

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -34,6 +34,7 @@
     path: /usr/lib/ckan/default
     state: directory
     mode: 0755
+    owner: ubuntu
 
 - name: create CKAN etc directory
   become: true
@@ -44,10 +45,12 @@
 
 - name: create CKAN virtualenv
   become: true
+  become_user: ubuntu
   command: virtualenv /usr/lib/ckan/default
 
 - name: install CKAN from git repository
   become: true
+  become_user: ubuntu
   pip:
     editable: true
     name: git+https://github.com/ckan/ckan.git@ckan-2.2.4#egg=ckan
@@ -55,6 +58,7 @@
 
 - name: install CKAN python requirements
   become: true
+  become_user: ubuntu
   pip:
     requirements: /usr/lib/ckan/default/src/ckan/requirements.txt
     virtualenv: /usr/lib/ckan/default
@@ -72,6 +76,7 @@
 
 - name: install pylibmc
   become: true
+  become_user: ubuntu
   pip:
     name: pylibmc
     virtualenv: /usr/lib/ckan/default

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -8,8 +8,6 @@
   apt: pkg={{ item }} state=installed
   with_items:
     - nginx
-    - apache2
-    - libapache2-mod-wsgi
     - libpq5
     - emacs
     - git

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # This playbook sets installs the CKAN application.
 - name: update apt-cache
-  sudo: true
+  become: true
   apt: update_cache=yes
 
 - name: install packages for CKAN
@@ -32,10 +32,10 @@
   get_url: 'url="http://packaging.ckan.org/{{ ckan_package_filename }}" dest=/tmp/{{ ckan_package_filename }}'
 
 - name: install CKAN package
-  sudo: true
+  become: true
   apt: deb=/tmp/{{ ckan_package_filename }}
   register: ckan_installed
 
 - name: install pylibmc
-  sudo: true
+  become: true
   pip: name=pylibmc virtualenv=/usr/lib/ckan/default

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -48,6 +48,14 @@
   become_user: ubuntu
   command: virtualenv /usr/lib/ckan/default
 
+- name: install an older setuptools for CKAN
+  become: true
+  become_user: ubuntu
+  pip:
+    name: setuptools
+    version: 36.1
+    virtualenv: /usr/lib/ckan/default
+
 - name: install CKAN from git repository
   become: true
   become_user: ubuntu

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -80,3 +80,15 @@
   pip:
     name: pylibmc
     virtualenv: /usr/lib/ckan/default
+
+- name: remove existing Solr schema.xml
+  file:
+    path: /etc/solr/conf/schema.xml
+    state: absent
+
+- name: link SOLR schema.xml from Ckan
+  file:
+    src: /usr/lib/ckan/default/src/ckan/ckan/config/solr/schema.xml
+    dest: /etc/solr/conf/schema.xml
+    state: link
+  notify: Restart Jetty

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -21,7 +21,6 @@
     - zip
     - screen
     - python-boto
-    - python-pip
     - python-virtualenv
     - libmemcached-dev
     - memcached

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -25,14 +25,53 @@
     - python-dev
     - build-essential
 
-- name: download CKAN package
-  get_url: 'url="http://packaging.ckan.org/{{ ckan_package_filename }}" dest=/tmp/{{ ckan_package_filename }}'
+# TODO: swap the following (except the pylibmc block) out for the old deb
+# install when CKAN release a 16.04 compatible version.
 
-- name: install CKAN package
+- name: create CKAN lib directory
   become: true
-  apt: deb=/tmp/{{ ckan_package_filename }}
-  register: ckan_installed
+  file:
+    path: /usr/lib/ckan/default
+    state: directory
+    mode: 0755
+
+- name: create CKAN etc directory
+  become: true
+  file:
+    path: /etc/ckan/default
+    state: directory
+    mode: 0755
+
+- name: create CKAN virtualenv
+  become: true
+  command: virtualenv /usr/lib/ckan/default
+
+- name: install CKAN from git repository
+  become: true
+  pip:
+    editable: true
+    name: git+https://github.com/ckan/ckan.git@ckan-2.2.4#egg=ckan
+    virtualenv: /usr/lib/ckan/default
+
+- name: install CKAN python requirements
+  become: true
+  pip:
+    requirements: /usr/lib/ckan/default/src/ckan/requirements.txt
+    virtualenv: /usr/lib/ckan/default
+
+- name: Add WSGI file
+  template:
+    src: config/apache.wsgi
+    dest: /etc/ckan/default/apache.wsgi
+
+- name: link who.ini
+  file:
+    src: /usr/lib/ckan/default/src/ckan/who.ini
+    dest: /etc/ckan/default/who.ini
+    state: link
 
 - name: install pylibmc
   become: true
-  pip: name=pylibmc virtualenv=/usr/lib/ckan/default
+  pip:
+    name: pylibmc
+    virtualenv: /usr/lib/ckan/default

--- a/ansible/roles/datastore/tasks/main.yml
+++ b/ansible/roles/datastore/tasks/main.yml
@@ -2,13 +2,24 @@
 # Sets up the datastore.
 
 - name: create DataStore database
-  sudo_user: postgres
-  postgresql_db: name={{ datastore_db }} owner={{ db_user }}
+  become: true
+  become_user: postgres
+  postgresql_db:
+    name={{ datastore_db }}
+    owner={{ db_user }}
 
 - name: set DataStore database owner
-  sudo_user: postgres
-  postgresql_user: 'db={{ datastore_db }} name={{ db_user }} password={{ db_password }} priv=ALL'
+  become: true
+  become_user: postgres
+  postgresql_user:
+    db={{ datastore_db }}
+    name={{ db_user }}
+    password={{ db_password }}
+    priv=ALL
 
 - name: create DataStore database user
-  sudo_user: postgres
-  postgresql_user: 'name={{ datastore_db_user }} password={{ datastore_db_password }}'
+  become: true
+  become_user: postgres
+  postgresql_user:
+    name={{ datastore_db_user }}
+    password={{ datastore_db_password }}

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -10,9 +10,18 @@
     - python-psycopg2
 
 - name: add ckan_default database user
-  sudo_user: postgres
-  postgresql_user: name={{ db_user }} password={{ db_password }} role_attr_flags=CREATEDB
+  become: true
+  become_user: postgres
+  postgresql_user:
+    name={{ db_user }}
+    password={{ db_password }}
+    role_attr_flags=CREATEDB
 
 - name: create ckan_default database
-  sudo_user: postgres
-  postgresql_db: name={{ db_name }} encoding='UTF-8' owner={{ db_user }} template=template0
+  become: true
+  become_user: postgres
+  postgresql_db:
+    name={{ db_name }}
+    encoding='UTF-8'
+    owner={{ db_user }}
+    template=template0

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -3,10 +3,11 @@
 - name: update apt-cache
   apt: update_cache=yes
 
-- name: install Postgres and psycopg2
+- name: install Postgres, its headers, and psycopg2
   apt: pkg={{ item }} state=installed
   with_items:
     - postgresql
+    - postgresql-server-dev-9.5
     - python-psycopg2
 
 - name: add ckan_default database user

--- a/ansible/roles/directory/tasks/main.yml
+++ b/ansible/roles/directory/tasks/main.yml
@@ -27,6 +27,8 @@
     - php5.6-curl
 
 - name: clone git repository
+  become: true
+  become_user: ubuntu
   git:
     repo: '{{ git_protocol }}github.com/nhsengland/datadirectory'
     dest: /home/ubuntu/datadirectory

--- a/ansible/roles/directory/tasks/main.yml
+++ b/ansible/roles/directory/tasks/main.yml
@@ -1,14 +1,30 @@
 ---
 # This playbook installs the data directory
 
+- name: install git
+  become: true
+  apt:
+    pkg: git
+    state: installed
+
+- name: add Launchpad's key ID
+  become: true
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: 14aa40ec0831756756d7f66c4f4ea0aae5267a6c
+
+- name: add PHP PPA
+  become: true
+  apt_repository:
+    repo: 'ppa:ondrej/php'
+
 - name: install packages for repos
   become: true
   apt: pkg={{ item }} state=installed
   with_items:
-    - git
-    - php5
-    - libapache2-mod-php5
-    - php5-curl
+    - php5.6
+    - libapache2-mod-php5.6
+    - php5.6-curl
 
 - name: clone git repository
   git:

--- a/ansible/roles/directory/tasks/main.yml
+++ b/ansible/roles/directory/tasks/main.yml
@@ -2,7 +2,7 @@
 # This playbook installs the data directory
 
 - name: install packages for repos
-  sudo: yes
+  become: true
   apt: pkg={{ item }} state=installed
   with_items:
     - git
@@ -11,18 +11,25 @@
     - php5-curl
 
 - name: clone git repository
-  git: repo={{ git_protocol }}github.com/nhsengland/datadirectory
-       dest=/home/ubuntu/datadirectory
-       version=master
+  git:
+    repo: '{{ git_protocol }}github.com/nhsengland/datadirectory'
+    dest: /home/ubuntu/datadirectory
+    version: master
 
 - name: copy apache2 config
-  sudo: yes
-  copy: src=config/apache2_ckan_default dest=/etc/apache2/sites-available/ckan_default.conf mode=0644 owner=root
+  become: true
+  template:
+    src: config/apache2_ckan_default
+    dest: /etc/apache2/sites-available/ckan_default.conf
+    mode: 0644
+    owner: root
 
 - name: restart Apache
-  sudo: yes
+  become: true
   service: name=apache2 state=restarted
 
 - name: delete nginx cache
-  sudo: yes
-  command: rm -rf /tmp/nginx_cache
+  become: true
+  file:
+    path: /tmp/nginx_cache
+    state: absent

--- a/ansible/roles/directory/tasks/main.yml
+++ b/ansible/roles/directory/tasks/main.yml
@@ -34,14 +34,6 @@
     dest: /home/ubuntu/datadirectory
     version: master
 
-- name: copy apache2 config
-  become: true
-  template:
-    src: config/apache2_ckan_default
-    dest: /etc/apache2/sites-available/ckan_default.conf
-    mode: 0644
-    owner: root
-
 - name: restart Apache
   become: true
   service: name=apache2 state=restarted

--- a/ansible/roles/email/tasks/main.yml
+++ b/ansible/roles/email/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 # This playbook configures email sending in a production environment.
 - name: copy push script
-  template: src=scripts/push_email.sh dest=/home/ubuntu/push_email.sh
+  template:
+    src: scripts/push_email.sh
+    dest: /home/ubuntu/push_email.sh
+    owner: ubuntu
 
 - name: configure CRON
   cron: name="push email" minute="0,5,10,15,20,25,30,35,40,45,50,55" user="ubuntu" job="/home/ubuntu/push_email.sh"

--- a/ansible/roles/pip/tasks/main.yml
+++ b/ansible/roles/pip/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Remove outdated system packaged pip
+  become: true
+  apt:
+    name: python-pip
+    state: absent
+
+- name: Download pip installer
+  get_url:
+    url: https://bootstrap.pypa.io/get-pip.py
+    dest: /tmp/get-pip.py
+    mode: 0440
+
+- name: Install pip
+  become: true
+  command: /usr/bin/python /tmp/get-pip.py
+  args:
+    creates: /usr/local/bin/pip
+
+- name: Ensure python package tools are up to date
+  become: true
+  pip:
+    name: '{{ item }}'
+    extra_args: '--upgrade'
+  with_items:
+    - pip
+    - setuptools

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -15,7 +15,7 @@
     - swig
     - python-dev
 
-- name: clone git repository
+- name: clone ckanext-nhsengland git repository
   become: true
   become_user: ubuntu
   git:
@@ -27,15 +27,3 @@
   become: true
   become_user: ubuntu
   command: /usr/lib/ckan/default/bin/python setup.py develop chdir=/home/ubuntu/ckanext-nhsengland
-
-- name: clone git repository
-  become: true
-  become_user: ubuntu
-  git:
-    repo: "{{ git_protocol }}{{ git_repos_adfs }}"
-    dest: /home/ubuntu/ckanext-adfs
-
-- name: run setup.py for adfs plugin
-  become: true
-  become_user: ubuntu
-  command: /usr/lib/ckan/default/bin/python setup.py develop chdir=/home/ubuntu/ckanext-adfs

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -21,6 +21,7 @@
   git:
     repo: "{{ git_protocol }}{{ git_repos_nhse }}"
     dest: /home/ubuntu/ckanext-nhsengland
+    version: reskin-nhs-england
 
 - name: run setup.py for nhsengland plugin
   become: true

--- a/ansible/roles/plugin/tasks/main.yml
+++ b/ansible/roles/plugin/tasks/main.yml
@@ -16,15 +16,25 @@
     - python-dev
 
 - name: clone git repository
-  git: repo={{ git_protocol }}{{ git_repos_nhse }}
-       dest=/home/ubuntu/ckanext-nhsengland
+  become: true
+  become_user: ubuntu
+  git:
+    repo: "{{ git_protocol }}{{ git_repos_nhse }}"
+    dest: /home/ubuntu/ckanext-nhsengland
 
-- name: run setup.py for the plugin
+- name: run setup.py for nhsengland plugin
+  become: true
+  become_user: ubuntu
   command: /usr/lib/ckan/default/bin/python setup.py develop chdir=/home/ubuntu/ckanext-nhsengland
 
 - name: clone git repository
-  git: repo={{ git_protocol }}{{ git_repos_adfs }}
-       dest=/home/ubuntu/ckanext-adfs
+  become: true
+  become_user: ubuntu
+  git:
+    repo: "{{ git_protocol }}{{ git_repos_adfs }}"
+    dest: /home/ubuntu/ckanext-adfs
 
-- name: run setup.py for the plugin
+- name: run setup.py for adfs plugin
+  become: true
+  become_user: ubuntu
   command: /usr/lib/ckan/default/bin/python setup.py develop chdir=/home/ubuntu/ckanext-adfs

--- a/ansible/roles/publishomatic/tasks/main.yml
+++ b/ansible/roles/publishomatic/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 # This playbook installs publishomatic
 - name: update apt-cache
-  sudo: true
+  become: true
   apt: update_cache=yes
 
 - name: install packages for repos
   apt: pkg={{ item }} state=installed
-  sudo: yes
+  become: true
   with_items:
     - git
     - libxml2
@@ -22,16 +22,16 @@
 # Create logging folder and lograte entry
 - name: Creates logging directory
   file: path=/var/log/publishomatic state=directory owner=ubuntu
-  sudo: yes
+  become: true
 
 # Creates logrotate file from config ...
 - name: Create our config file for scraping
   template: src=config/publishomatic.logrotate.conf dest=/etc/logrotate.d/publishomatic
-  sudo: yes
+  become: true
 
 - name: Install required Python packages.
   easy_install: name={{ item }}
-  sudo: yes
+  become: true
   with_items:
     - pip
     - virtualenv
@@ -48,7 +48,7 @@
   template: src=config/dms.ini dest=/home/ubuntu/dms.ini
 
 - shell: whoami && bin/crontool | crontab
-  sudo_user: ubuntu
+  become_user: ubuntu
   args:
     chdir: /home/ubuntu/publishomatic/
 

--- a/ansible/roles/solr/handlers/main.yml
+++ b/ansible/roles/solr/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # Handlers for Jetty / SOLR
 - name: Start Jetty
-  service: name=jetty state=started
+  service: name=jetty8 state=started
 
 - name: Restart Jetty
-  service: name=jetty state=restarted
+  service: name=jetty8 state=restarted

--- a/ansible/roles/solr/tasks/main.yml
+++ b/ansible/roles/solr/tasks/main.yml
@@ -21,12 +21,10 @@
 - name: update SOLR configuration - JAVA_HOME
   lineinfile: 'dest=/etc/default/jetty8 regexp=JAVA_HOME line="JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/"'
 
-- name: backup SOLR schema.xml
-  command: mv /etc/solr/conf/schema.xml /etc/solr/conf/schema.xml.bak
-
 - name: copy solrconfig.xml
-  copy: src=config/solrconfig.xml dest=/etc/solr/conf/solrconfig.xml mode=0644 owner=root
-
-- name: update SOLR schema.xml
-  file: path=/etc/solr/conf/schema.xml src=/usr/lib/ckan/default/src/ckan/ckan/config/solr/schema.xml state=link
+  template:
+    src: config/solrconfig.xml
+    dest: /etc/solr/conf/solrconfig.xml
+    mode: 644
+    owner: root
   notify: Restart Jetty

--- a/ansible/roles/solr/tasks/main.yml
+++ b/ansible/roles/solr/tasks/main.yml
@@ -7,19 +7,19 @@
   apt: pkg={{ item }} state=installed
   with_items:
     - solr-jetty
-    - openjdk-6-jdk
+    - openjdk-8-jdk
 
 - name: update SOLR configuration - NO_START
-  lineinfile: 'dest=/etc/default/jetty regexp=^NO_START line="NO_START=0"'
+  lineinfile: 'dest=/etc/default/jetty8 regexp=^NO_START line="NO_START=0"'
 
 - name: update SOLR configuration - JETTY_HOST
-  lineinfile: 'dest=/etc/default/jetty regexp=^JETTY_HOST line="JETTY_HOST={{ solr_host }}"'
+  lineinfile: 'dest=/etc/default/jetty8 regexp=^JETTY_HOST line="JETTY_HOST={{ solr_host }}"'
 
 - name: update SOLR configuration - JETTY_PORT
-  lineinfile: 'dest=/etc/default/jetty regexp=^JETTY_PORT line="JETTY_PORT={{ solr_port }}"'
+  lineinfile: 'dest=/etc/default/jetty8 regexp=^JETTY_PORT line="JETTY_PORT={{ solr_port }}"'
 
 - name: update SOLR configuration - JAVA_HOME
-  lineinfile: 'dest=/etc/default/jetty regexp=JAVA_HOME line="JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64/"'
+  lineinfile: 'dest=/etc/default/jetty8 regexp=JAVA_HOME line="JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/"'
 
 - name: backup SOLR schema.xml
   command: mv /etc/solr/conf/schema.xml /etc/solr/conf/schema.xml.bak

--- a/ansible/roles/ssl/tasks/main.yml
+++ b/ansible/roles/ssl/tasks/main.yml
@@ -11,3 +11,14 @@
 
 - name: copy nginx config
   copy: src=config/nginx_ckan dest=/etc/nginx/sites-available/ckan mode=0644 owner=root
+
+- name: deactivate default nginx site
+  file:
+    name: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: activate ckan nginx site
+  file:
+    src: /etc/nginx/sites-available/ckan
+    dest: /etc/nginx/sites-enabled/ckan
+    state: link

--- a/ansible/roles/ssl/tasks/main.yml
+++ b/ansible/roles/ssl/tasks/main.yml
@@ -11,6 +11,3 @@
 
 - name: copy nginx config
   copy: src=config/nginx_ckan dest=/etc/nginx/sites-available/ckan mode=0644 owner=root
-
-- name: copy apache2 config
-  copy: src=config/apache2_ckan_default dest=/etc/apache2/sites-available/ckan_default.conf mode=0644 owner=root

--- a/ansible/rollback.yml
+++ b/ansible/rollback.yml
@@ -9,7 +9,7 @@
 
 - name: rollback
   hosts: webservers
-  sudo: yes
+  become: true
   user: ubuntu
   gather_facts: false
 


### PR DESCRIPTION
These changes cover two high level areas:
* Upgrade Ubuntu to 16.04
* Upgrade minimum Ansible to 2.4

#### Ubuntu
12.04's system `pip` was too old to connect to PyPI (which now requires HTTPS) and ships a too old version of OpenSSL for latest `pip` to connect either.  We made the decision to switch to the latest LTS (16.04) to save further upgrade work in the medium term.  However this had the knock-on effect of requiring a source install of CKAN and some ansible updates to deal with Ubuntu's move to systemd.

#### Ansible
After 2.2 Ansible deprecated (and ignores!) `sudo[_user]` attributes in plays, instead using the `become[_user]` attributes.  The semantics of these new attributes required we turn on pipelining to avoid permission errors with Ansible's temp file.