### PR TITLE
Script upgrade of CKAN source installation from 2.2 -> 2.7

### DIFF
--- a/ansible/roles/upgrade/tasks/looped_tasks.yml
+++ b/ansible/roles/upgrade/tasks/looped_tasks.yml
@@ -1,0 +1,16 @@
+---
+- name: install CKAN {{ version }} from git repository
+  pip:
+    editable: true
+    name: git+https://github.com/ckan/ckan.git@ckan-{{ version }}#egg=ckan
+    virtualenv: /usr/lib/ckan/default
+
+- name: install CKAN python requirements
+  become: true
+  pip:
+    requirements: /usr/lib/ckan/default/src/ckan/requirements.txt
+    virtualenv: /usr/lib/ckan/default
+
+- name: upgrade Database schema
+  become: true
+  command: /usr/lib/ckan/default/bin/paster --plugin=ckan db upgrade --config /etc/ckan/default/production.ini

--- a/ansible/roles/upgrade/tasks/main.yml
+++ b/ansible/roles/upgrade/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- include_tasks: looped_tasks.yml
+  with_items:
+    - 2.3.5
+    - 2.4.9
+    - 2.5.7
+    - 2.6.4
+    - 2.7.2
+
+  loop_control:
+    loop_var: version
+
+- name: install redis server
+  become: true
+  apt:
+    name: redis-server
+    state: present
+    update_cache: yes
+
+- name: update board_report dataset
+  become: true
+  become_user: postgres
+  command: psql ckan_default -c "UPDATE resource SET format = 'CSV' WHERE package_id = '2c5c458b-8a2f-4319-bd6a-58fd00b70e74';"
+
+- name: "rename *_preview -> *_view in production.ini"
+  become: true
+  ini_file:
+    path: /etc/ckan/default/production.ini
+    section: "app:main"
+    option: ckan.plugins
+    value: stats text_view recline_view nhsengland_skin datastore datapusher adfs
+    backup: yes
+
+- name: add default views setting to production.ini
+  become: true
+  ini_file:
+    path: /etc/ckan/default/production.ini
+    section: "app:main"
+    option: ckan.views.default_views
+    value: recline_view
+    backup: yes
+
+- name: add default views setting to production.ini
+  become: true
+  ini_file:
+    path: /etc/ckan/default/production.ini
+    section: "app:main"
+    option: ckan.site_url
+    value: "http://{{ inventory_hostname }}"
+    backup: yes
+
+- name: restart jetty
+  become: true
+  service:
+    name: jetty8
+    state: restarted
+
+- name: rebuild Solr schema
+  become: true
+  command: /usr/lib/ckan/default/bin/paster --plugin=ckan search-index rebuild --config /etc/ckan/default/production.ini
+
+- name: create views
+  become: true
+  command: /usr/lib/ckan/default/bin/paster --plugin=ckan views create -y --config=/etc/ckan/default/production.ini
+
+- name: upgrade requests
+  become: true
+  become_user: ubuntu
+  pip:
+    name: requests[security]
+    virtualenv: /usr/lib/ckan/default
+
+- name: update datastore permissions
+  become: true
+  shell: /usr/lib/ckan/default/bin/paster --plugin=ckan datastore set-permissions --config=/etc/ckan/default/production.ini | sudo -u postgres psql --set ON_ERROR_STOP=1
+
+- name: restart apache
+  become: true
+  service:
+    name: apache2
+    state: restarted

--- a/ansible/roles/upgrade/tasks/main.yml
+++ b/ansible/roles/upgrade/tasks/main.yml
@@ -17,6 +17,9 @@
     state: present
     update_cache: yes
 
+# The Board Report dataset has a CSV resource that doesn't have its `format`
+# field filled in.  This meant no data views were created for the resource.
+# This resolves that problem by fixing the offending resource row in the db.
 - name: update board_report dataset
   become: true
   become_user: postgres

--- a/ansible/upgrade.yml
+++ b/ansible/upgrade.yml
@@ -1,0 +1,13 @@
+---
+# This playbook upgrades NHS Englands CKAN instance from 2.2 -> 2.7.  It does a
+# source install for each version up to 2.7 to upgrade the database schema for
+# each major version bump.  Then it moves the install to the Ubuntu 16.04
+# compatible deb install.
+
+- name: "Upgrade CKAN from 2.2 -> 2.7"
+  hosts: webservers
+  user: ubuntu
+  roles:
+    - upgrade
+
+# - name: "Switch to 2.7 deb"


### PR DESCRIPTION
This adds a playbook to upgrade a server built from the [current master](https://github.com/nhsengland/iit-infrastructure/tree/e3ebaa8e0f5d01dcd34af2fedab98aef1a5468fa) to the latest CKAN.  It performs the necessary steps to migrate through the five version upgrades fixing breaking changes along the way.  The playbook has been built with the assumption that it will be deleted after the upgrade process has been done and deployed into production.  It has been written to be a serial upgrade flow and is _not_ idempotent.

Closes #17.
Fixes #22 